### PR TITLE
fix: update AddressMapper.kt

### DIFF
--- a/places-compose/src/main/java/com/google/android/libraries/places/compose/autocomplete/domain/mappers/AddressMapper.kt
+++ b/places-compose/src/main/java/com/google/android/libraries/places/compose/autocomplete/domain/mappers/AddressMapper.kt
@@ -51,15 +51,11 @@ fun List<AddressComponent>.toAddress(): Address {
 
 class AddressComponentMultiMap(components: Collection<AddressComponent>) {
     // Initialize a map to store address components grouped by their types
-    private val componentsByType = run {
-        val map = mutableMapOf<String, MutableList<AddressComponent>>()
-        components.forEach { addressComponent ->
-            addressComponent.types.forEach {
-                map.getOrPut(it) { mutableListOf() }.add(addressComponent)
-            }
+    private val componentsByType: Map<String, List<AddressComponent>> = components
+        .flatMap { addressComponent -> 
+            addressComponent.types.map { type -> type to addressComponent } 
         }
-        map
-    }
+        .groupBy({ it.first }, { it.second })
 
     operator fun get(type: AddressComponentType) =
         componentsByType[type.name.lowercase()]


### PR DESCRIPTION
**Use of `flatMap`:**
The flatMap function is used to transform each AddressComponent into pairs of type and the component itself. This flattens the structure into a single list of pairs, making it easier to group by type.

**Use of `groupBy`:**
The groupBy function is then applied to this list of pairs. It takes a selector for the key (the type) and a selector for the value (the AddressComponent). This eliminates the need for manual initialization and population of the map.

**Immutable Map:**
The result is an immutable Map<String, List<AddressComponent>>, which is generally preferred in Kotlin for better safety and clarity.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
