### PR TITLE
chore: not using Base64 decode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         distribution: 'adopt'
     - name: Create .gpg key
       run: |
-        echo $GPG_KEY_ARMOR | ./release.asc
+        echo $GPG_KEY_ARMOR > ./release.asc
         gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
 
         echo "Build and publish"


### PR DESCRIPTION
This PR removes the base64 decode step from our release flow.