### PR TITLE
chore: rebased commits

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lint and Upload SARIF
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+
+      - name: Run Android Lint
+        run: ./gradlew lint
+
+      - name: Merge SARIF files
+        run: |
+          jq -s '{ "$schema": "https://json.schemastore.org/sarif-2.1.0", "version": "2.1.0", "runs": map(.runs) | add }'  places-compose/build/reports/lint-results.sarif  places-compose-demo/build/reports/lint-results.sarif > merged.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: merged.sarif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       run: npm i -D conventional-changelog-conventionalcommits
 
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@v4.1.0
+      uses: cycjimmy/semantic-release-action@v4.1.1
       with:
         extra_plugins: |
           "@semantic-release/commit-analyzer@8.0.1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
-    - uses: gradle/actions/wrapper-validation@v3
+    - uses: gradle/actions/wrapper-validation@v4
     - name: Set up JDK 21
       uses: actions/setup-java@v4.2.1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         distribution: 'adopt'
     - name: Create .gpg key
       run: |
-        echo $GPG_KEY_ARMOR > ./release.asc
+        echo $GPG_KEY_ARMOR | base64 --decode > ./release.asc
         gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
 
         echo "Build and publish"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         distribution: 'adopt'
     - name: Create .gpg key
       run: |
-        echo $GPG_KEY_ARMOR | base64 --decode > ./release.asc
+        echo $GPG_KEY_ARMOR > ./release.asc
         gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
 
         echo "Build and publish"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+    - uses: gradle/actions/wrapper-validation@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4.2.1
+      with:
+        java-version: '21'
+        distribution: 'adopt'
+    - name: Create .gpg key
+      run: |
+        echo $GPG_KEY_ARMOR | base64 --decode > ./release.asc
+        gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
+
+        echo "Build and publish"
+        sed -i -e "s,sonatypeToken=,sonatypeToken=$SONATYPE_TOKEN_USERNAME,g" gradle.properties
+        SONATYPE_TOKEN_PASSWORD_ESCAPED=$(printf '%s\n' "$SONATYPE_TOKEN_PASSWORD" | sed -e 's/[\/&]/\\&/g')
+        sed -i -e "s,sonatypeTokenPassword=,sonatypeTokenPassword=$SONATYPE_TOKEN_PASSWORD_ESCAPED,g" gradle.properties
+        sed -i -e "s,signing.keyId=,signing.keyId=$GPG_KEY_ID,g" gradle.properties
+        sed -i -e "s,signing.password=,signing.password=$GPG_PASSWORD,g" gradle.properties
+        sed -i -e "s,signing.secretKeyRingFile=,signing.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg,g" gradle.properties
+      env:
+        GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
+        GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
+        GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
+        SONATYPE_TOKEN_PASSWORD: ${{ secrets.SYNCED_SONATYPE_TOKEN_PASSWORD }}
+        SONATYPE_TOKEN_USERNAME: ${{ secrets.SYNCED_SONATYPE_TOKEN_USERNAME }}
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '14'
+    
+    - name: Install conventionalcommits
+      run: npm i -D conventional-changelog-conventionalcommits
+
+    - name: Semantic Release
+      uses: cycjimmy/semantic-release-action@v4.1.0
+      with:
+        extra_plugins: |
+          "@semantic-release/commit-analyzer@8.0.1"
+          "@semantic-release/release-notes-generator@9.0.3"
+          "@google/semantic-release-replace-plugin@1.2.0"
+          "@semantic-release/exec@5.0.0"
+          "@semantic-release/git@9.0.1"
+          "@semantic-release/github@7.2.3"
+      env:
+        GH_TOKEN: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,25 @@
+branches:
+  - main
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - - "@google/semantic-release-replace-plugin"
+    - replacements:
+        - files:
+            - "build.gradle.kts"
+          from: "\\bversion = \".*\""
+          to: "version = \"${nextRelease.version}\""
+        - files:
+            - "README.md"
+          from: ":([0-9]+).([0-9]+).([0-9]+)"
+          to: ":${nextRelease.version}"
+  - - "@semantic-release/exec"
+    - prepareCmd: "./gradlew build --warn --stacktrace"
+      publishCmd: "./gradlew publish --warn --stacktrace"
+  - - "@semantic-release/git"
+    - assets:
+        - "build.gradle.kts"
+        - "*.md"
+  - "@semantic-release/github"
+options:
+  debug: true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# Android Places Compose Library
+![Maven Central Version](https://img.shields.io/maven-central/v/com.google.maps.android/places-compose)
+![Static Badge](https://img.shields.io/badge/release-alpha-orange) ![GitHub License](https://img.shields.io/github/license/googlemaps/android-places-compose)
+
+
+# Android Places Compose Library (Alpha)
 
 ## Description
 
 This is a Jetpack Compose library for the Google Maps Platform Places SDK for Android. It provides a
-reusable Places Autocomplete Compose widget.  
+reusable Place Autocomplete composable based on the [new Places API](https://mapsplatform.google.com/resources/blog/the-next-generation-of-autocomplete-is-now-generally-available/).  
 
-Additionally, there is a sample app showing how to use the widget as well as demonstrating 
+Additionally, there is a [sample app](https://github.com/googlemaps/android-places-compose/tree/main/places-compose-demo) showing how to use the widget as well as demonstrating 
 [Address Descriptors](https://developers.google.com/maps/documentation/geocoding/address-descriptors/requests-address-descriptors)
 and address entry.
 
@@ -13,12 +17,13 @@ and address entry.
 
 * Android API 24 (or newer) (Android 7.0 Nougat)  
 * Android Studio (Koala or newer recommended)
+* A Google Maps Platform [API key](https://developers.google.com/maps/documentation/places/android-sdk/get-api-key) from a project with the [**Places API (New)** enabled](https://developers.google.com/maps/documentation/places/android-sdk/cloud-setup#enabling-apis).
 
 ## Installation
 
-Maven artifacts are coming soon...
+Add the dependency below to your **module-level** Gradle build file:
 
-Add the dependency below to your module's `build.gradle.kts` file:
+### Kotlin (`build.gradle.kts`)
 
 ```kotlin
 dependencies {
@@ -26,13 +31,21 @@ dependencies {
 }
 ```
 
+### Groovy (`build.gradle`)
+
+```groovy
+dependencies {
+    implementation 'com.google.maps.android:places-compose:0.1.0'
+}
+```
+
 ## Sample App
 
-This repository includes a full-featured demo app that demonstrates how to use the library. To run the demo app, follow these steps:
+This repository includes a full-featured [demo app](https://github.com/googlemaps/android-places-compose/tree/main/places-compose-demo) that demonstrates how to use the library. To run the demo app, follow these steps:
 
 1. Clone the repository
 2. [Get a Places API key][api-key]
-3. Copy `local.defaults.properties` to `secrets.properties` and replace `DEFAULT_API_KEY` with your API key(s). (Note: this file should *NOT* be
+3. Copy `local.defaults.properties` to a new file in the same folder `secrets.properties` and replace `DEFAULT_API_KEY` with your API key(s). (Note: this file should *NOT* be
    under version control to protect your API key)
 4. Build and run
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,3 +13,9 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ksp)
 }
+
+allprojects {
+    group = "com.google.maps.android"
+    version = "0.1.0"
+    val projectArtifactId by extra { project.name }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,9 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
+
 sonatypeToken=
 sonatypeTokenPassword=

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+sonatypeToken=
+sonatypeTokenPassword=

--- a/places-compose-demo/build.gradle.kts
+++ b/places-compose-demo/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 }
 
 android {
+    lint {
+        sarifOutput = file("$buildDir/reports/lint-results.sarif")
+    }
+
     namespace = "com.google.android.libraries.places.compose.demo"
     compileSdk = 35
 

--- a/places-compose/build.gradle.kts
+++ b/places-compose/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
 }
 
 android {
+    lint {
+        sarifOutput = file("$buildDir/reports/lint-results.sarif")
+    }
+
     namespace = "com.google.android.libraries.places.compose"
     compileSdk = 34
 

--- a/places-compose/src/main/java/com/google/android/libraries/places/compose/autocomplete/domain/mappers/AddressMapper.kt
+++ b/places-compose/src/main/java/com/google/android/libraries/places/compose/autocomplete/domain/mappers/AddressMapper.kt
@@ -51,15 +51,11 @@ fun List<AddressComponent>.toAddress(): Address {
 
 class AddressComponentMultiMap(components: Collection<AddressComponent>) {
     // Initialize a map to store address components grouped by their types
-    private val componentsByType = run {
-        val map = mutableMapOf<String, MutableList<AddressComponent>>()
-        components.forEach { addressComponent ->
-            addressComponent.types.forEach {
-                map.getOrPut(it) { mutableListOf() }.add(addressComponent)
-            }
+    private val componentsByType: Map<String, List<AddressComponent>> = components
+        .flatMap { addressComponent -> 
+            addressComponent.types.map { type -> type to addressComponent } 
         }
-        map
-    }
+        .groupBy({ it.first }, { it.second })
 
     operator fun get(type: AddressComponentType) =
         componentsByType[type.name.lowercase()]


### PR DESCRIPTION
This PR removes the commit 51a488cdfb367e3b012182ea7aa558d0ccd9d7fa, renames the commit 78f9e26175a18f40a7daa6577f72f8e61580e97d to chore, so we can trigger a 0.1.1 release.