### PR TITLE
chore: downgraded version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the dependency below to your **module-level** Gradle build file:
 
 ```kotlin
 dependencies {
-    implementation("com.google.maps.android:places-compose:0.2.0")
+    implementation("com.google.maps.android:places-compose:0.1.1")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,6 @@ plugins {
 
 allprojects {
     group = "com.google.maps.android"
-    version = "0.2.0"
+    version = "0.1.1"
     val projectArtifactId by extra { project.name }
 }


### PR DESCRIPTION
This PR downgrades the version on the README and the build.gradle.kts file from 0.2.0 to 0.1.1