### PR TITLE
chore: migrating to vanniktech plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,14 @@ jobs:
         gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
 
         echo "Build and publish"
-        sed -i -e "s,sonatypeToken=,sonatypeToken=$SONATYPE_TOKEN_USERNAME,g" gradle.properties
+        sed -i -e "s,mavenCentralUsername=,mavenCentralUsername=$SONATYPE_TOKEN_USERNAME,g" gradle.properties
         SONATYPE_TOKEN_PASSWORD_ESCAPED=$(printf '%s\n' "$SONATYPE_TOKEN_PASSWORD" | sed -e 's/[\/&]/\\&/g')
-        sed -i -e "s,sonatypeTokenPassword=,sonatypeTokenPassword=$SONATYPE_TOKEN_PASSWORD_ESCAPED,g" gradle.properties
+        sed -i -e "s,mavenCentralPassword=,mavenCentralPassword=$SONATYPE_TOKEN_PASSWORD_ESCAPED,g" gradle.properties
         sed -i -e "s,signing.keyId=,signing.keyId=$GPG_KEY_ID,g" gradle.properties
         sed -i -e "s,signing.password=,signing.password=$GPG_PASSWORD,g" gradle.properties
         sed -i -e "s,signing.secretKeyRingFile=,signing.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg,g" gradle.properties
       env:
-        GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
+        GPG_KEY_ARMOR: ${{ secrets.SYNCED_GPG_KEY_ARMOR }}
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
         SONATYPE_TOKEN_PASSWORD: ${{ secrets.SYNCED_SONATYPE_TOKEN_PASSWORD }}

--- a/.releaserc
+++ b/.releaserc
@@ -15,7 +15,7 @@ plugins:
           to: ":${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: "./gradlew build --warn --stacktrace"
-      publishCmd: "./gradlew publish --warn --stacktrace"
+      publishCmd: "./gradlew publishToMavenCentral --warn --stacktrace"
   - - "@semantic-release/git"
     - assets:
         - "build.gradle.kts"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(libs.android.gradle.plugin)
     implementation(libs.dokka.plugin)
     implementation(libs.org.jacoco.core)
+    implementation(libs.gradle.maven.publish.plugin)
 }
 
 gradlePlugin {

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -1,38 +1,34 @@
 // buildSrc/src/main/kotlin/PublishingConventionPlugin.kt
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.*
-import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
-import org.gradle.plugins.signing.SigningExtension
-import org.gradle.api.publish.maven.*
 
 class PublishingConventionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
-
             applyPlugins()
             configureJacoco()
-            configurePublishing()
-            configureSigning()
+            configureMavenPublishing()
         }
     }
 
     private fun Project.applyPlugins() {
         apply(plugin = "com.android.library")
         apply(plugin = "com.mxalbert.gradle.jacoco-android")
-        apply(plugin = "maven-publish")
         apply(plugin = "org.jetbrains.dokka")
-        apply(plugin = "signing")
+        apply(plugin = "com.vanniktech.maven.publish")
     }
 
     private fun Project.configureJacoco() {
         configure<JacocoPluginExtension> {
             toolVersion = "0.8.7"
-
         }
 
         tasks.withType<Test>().configureEach {
@@ -43,68 +39,44 @@ class PublishingConventionPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.configurePublishing() {
-        extensions.configure<com.android.build.gradle.LibraryExtension> {
-            publishing {
-                singleVariant("release") {
-                    withSourcesJar()
-                    withJavadocJar()
-                }
-            }
-        }
-        extensions.configure<PublishingExtension> {
-            publications {
-                create<MavenPublication>("aar") {
-                    afterEvaluate {
-                        from(components["release"])
+    private fun Project.configureMavenPublishing() {
+        extensions.configure<MavenPublishBaseExtension> {
+            configure(
+                AndroidSingleVariantLibrary(
+                    variant = "release",
+                    sourcesJar = true,
+                    publishJavadocJar = true
+                )
+            )
+            publishToMavenCentral()
+            signAllPublications()
+            pom {
+                name.set(project.name)
+                description.set("Jetpack Compose components for the Places SDK for Android")
+                url.set("https://github.com/googlemaps/android-places-compose")
+                licenses {
+                    license {
+                        name.set("The Apache Software License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        distribution.set("repo")
                     }
-                    pom {
-                        name.set(project.name)
-                        description.set("Jetpack Compose components for the Places SDK for Android")
-                        url.set("https://github.com/googlemaps/android-places-compose")
-                        scm {
-                            connection.set("scm:git@github.com:googlemaps/android-places-compose.git")
-                            developerConnection.set("scm:git@github.com:googlemaps/android-places-compose.git")
-                            url.set("https://github.com/googlemaps/android-places-compose")
-                        }
-                        licenses {
-                            license {
-                                name.set("The Apache Software License, Version 2.0")
-                                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                                distribution.set("repo")
-                            }
-                        }
-                        organization {
-                            name.set("Google Inc")
-                            url.set("http://developers.google.com/maps")
-                        }
-                        developers {
-                            developer {
-                                name.set("Google Inc.")
-                            }
-                        }
+                }
+                scm {
+                    connection.set("scm:git@github.com:googlemaps/android-places-compose.git")
+                    developerConnection.set("scm:git@github.com:googlemaps/android-places-compose.git")
+                    url.set("https://github.com/googlemaps/android-places-compose")
+                }
+                organization {
+                    name.set("Google Inc")
+                    url.set("http://developers.google.com/maps")
+                }
+                developers {
+                    developer {
+                        id.set("google")
+                        name.set("Google Inc.")
                     }
                 }
             }
-            repositories {
-                maven {
-                    val releasesRepoUrl =
-                        uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-                    val snapshotsRepoUrl =
-                        uri("https://central.sonatype.com/repository/maven-snapshots/")
-                    url = if (project.version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-                    credentials {
-                        username = project.findProperty("sonatypeToken") as String?
-                        password = project.findProperty("sonatypeTokenPassword") as String?
-                    }
-                }
-            }
-        }
-    }
-
-    private fun Project.configureSigning() {
-        configure<SigningExtension> {
-            sign(extensions.getByType<PublishingExtension>().publications["aar"])
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,9 +26,6 @@ signing.keyId=
 signing.password=
 signing.secretKeyRingFile=
 
-sonatypeToken=
-sonatypeTokenPassword=
-
 mavenCentralUsername=
 mavenCentralPassword=
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,10 @@ signing.secretKeyRingFile=
 
 sonatypeToken=
 sonatypeTokenPassword=
+
+mavenCentralUsername=
+mavenCentralPassword=
+
+# Add a property to enable automatic release to Maven Central (optional, but good for CI)
+# If true, publishToMavenCentral will also close and release the staging repository
+mavenCentralAutomaticRelease=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ secretsGradlePlugin = "2.0.1"
 truth = "1.4.4"
 uiTestAndroid = "1.7.8"
 uiToolingVersion = "1.7.8"
+gradleMavenPublishPlugin = "0.34.0"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -72,6 +73,7 @@ places = { group = "com.google.android.libraries.places", name = "places", versi
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "uiToolingVersion" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiToolingVersion" }
+gradle-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "gradleMavenPublishPlugin" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
The following PR migrates from the maven-publish plugin to vanniktech, to support the new Maven Central.

This PR provides the new configuration and data we need (including the maven central username and password)