### PR TITLE
build: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,16 +29,16 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4.7.1
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     # Run dokka and create tar
     - name: Generate documentation

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run Android Lint
         run: ./gradlew lint
@@ -42,11 +42,11 @@ jobs:
       - name: Upload SARIF for places-compose
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: places-compose/build/reports/lint-results-debug.sarif
+          sarif_file: places-compose/build/reports/lint-results.sarif
           category: places-compose
 
       - name: Upload SARIF for places-compose-demo
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: places-compose-demo/build/reports/lint-results-debug.sarif
+          sarif_file: places-compose-demo/build/reports/lint-results.sarif
           category: places-compose-demo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,18 +23,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           
       - name: Set up JDK 21
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
           
       - name: Create .gpg key
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,26 +30,26 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4.7.1
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build modules
       run: ./gradlew build jacocoTestReport --stacktrace
 
     - name: Jacoco Report to PR
       id: jacoco
-      uses: madrapps/jacoco-report@v1.7.1
+      uses: madrapps/jacoco-report@v1.7.2
       with:
         paths: |
-          ${{ github.workspace }}/places-compose/build/jacoco/jacoco.xml
+          ${{ github.workspace }}/places-compose/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
         min-coverage-overall: 26
         min-coverage-changed-files: 60
@@ -64,7 +64,9 @@ jobs:
 
     - name: Upload test reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-reports
-        path: ./app/build/reports
+        path: |
+          places-compose/build/reports
+          places-compose-demo/build/reports

--- a/places-compose-demo/build.gradle.kts
+++ b/places-compose-demo/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     lint {
-        sarifOutput = file("${layout.buildDirectory}/reports/lint-results.sarif")
+        sarifOutput = layout.buildDirectory.file("reports/lint-results.sarif").get().asFile
     }
 
     namespace = "com.google.android.libraries.places.compose.demo"

--- a/places-compose/build.gradle.kts
+++ b/places-compose/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     lint {
-        sarifOutput = file("${layout.buildDirectory}/reports/lint-results.sarif")
+        sarifOutput = layout.buildDirectory.file("reports/lint-results.sarif").get().asFile
     }
 
     namespace = "com.google.android.libraries.places.compose"

--- a/places-compose/build.gradle.kts
+++ b/places-compose/build.gradle.kts
@@ -31,6 +31,10 @@ android {
                 "proguard-rules.pro"
             )
         }
+        debug {
+            enableUnitTestCoverage = true
+            enableAndroidTestCoverage = true
+        }
     }
 
     java {


### PR DESCRIPTION
## Summary
This PR updates all GitHub Action workflows to their latest stable major versions and fixes several path inconsistencies.

### Upgrades
- `actions/checkout`: v4 -> v6
- `actions/setup-java`: v4.7.1 -> v5 (migrated distribution from `adopt` to `temurin`)
- `gradle/actions/setup-gradle`: v5 -> v6
- `actions/upload-artifact`: v4 -> v7
- `madrapps/jacoco-report`: v1.7.1 -> v1.7.2

### Path Fixes
- Corrected SARIF file paths in `lint-report.yml` from `lint-results-debug.sarif` to `lint-results.sarif`.
- Fixed artifact upload path in `test.yml` by removing the non-existent `app/` directory and adding correct paths for `places-compose` and `places-compose-demo` modules.
- Updated JaCoCo XML path in `test.yml` to match standard Gradle output: `places-compose/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml`.