### PR TITLE
docs: add guidelines for AI-assisted contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ information on using pull requests.
 
 Reviews will undergo strict enforcement of the [Jetpack Compose API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md).
 
+## AI-Assisted Contributions
+
+We welcome contributions generated or assisted by AI/LLM tools, provided you adhere to our project guidelines and maintain full ownership of your work. As the submitting author, you assume complete responsibility and accountability for all submitted code, documentation, tests, and pull request descriptions. Please thoroughly review, test, and validate all generated output—ensuring it follows idiomatic Kotlin and Android architectural standards—before submitting. Contributions must comply with the standard Google Contributor License Agreement (CLA), AI tools must not be listed as authors or co-authors on commits or PRs, and running automated agents to submit mass issues, scripted linters, or unsolicited, bot-generated pull requests without prior human discussion is strictly prohibited.
+
 ## Community Guidelines
 
 This project follows


### PR DESCRIPTION
## Description

Updates `CONTRIBUTING.md` with guidelines for AI-assisted contributions.

This policy outlines:
- Complete author ownership and accountability for submitted code, docs, and tests.
- Adherence to idiomatic Kotlin and Android architectural standards.
- Google Contributor License Agreement (CLA) compliance.
- AI tools must not be listed as authors/co-authors on commits or PRs.
- Prohibition of mass-issue submission or bot-generated pull requests without prior human discussion.
